### PR TITLE
fix(auth): Fixed 401 error on redeployment/ build

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,4 +1,4 @@
-// useAuth.ts
+import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, ReactNode, useCallback } from "react";
 import { getToken, removeToken, storeToken } from "../utils/auth";
@@ -35,62 +35,108 @@ const fetchUser = async () => {
 };
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-    const queryClient = useQueryClient();
-    const navigate = useNavigate();
-    const location = useLocation();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    const { data: user, isLoading } = useQuery({
-        queryKey: ['user'],
-        queryFn: fetchUser,
-        retry: false,
-        staleTime: Infinity,
-    });
+  const { data: user, isLoading } = useQuery({
+    queryKey: ["user"],
+    queryFn: fetchUser,
+    retry: false,
+    staleTime: Infinity,
+  });
 
-    const login = useCallback((userData: UserProfile, token: string) => {
-        queryClient.setQueryData(['user'], userData);
-        storeToken(token);
-    }, [queryClient]);
+  const login = useCallback(
+    (userData: UserProfile, token: string) => {
+      queryClient.setQueryData(["user"], userData);
+      storeToken(token);
+    },
+    [queryClient]
+  );
 
-    const logout = useCallback(() => {
-        removeToken();
-        queryClient.setQueryData(['user'], null);
-        navigate('/login');
-    }, [queryClient, navigate]);
+  const logout = useCallback(() => {
+    removeToken();
+    queryClient.setQueryData(["user"], null);
+    navigate("/login");
+  }, [queryClient, navigate]);
 
-    const handleAuthCallback = useCallback(() => {
-        const params = new URLSearchParams(location.search);
-        const encodedData = params.get('data');
-        const error = params.get('error');
-
-        if (error) {
-            console.error('Authentication error:', error);
-            navigate('/login', { state: { error } });
-            return;
+  // Axios interceptor for 401 errors
+  useEffect(() => {
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.response?.status === 401) {
+          // Clear all queries and cached data
+          queryClient.clear();
+          // Handle the logout
+          logout();
+          // You might want to preserve the intended destination
+          const destination = location.pathname;
+          if (destination !== "/login") {
+            navigate("/login", {
+              state: {
+                returnTo: destination,
+                error: "Your session has expired. Please log in again.",
+              },
+            });
+          }
         }
-
-        if (encodedData) {
-            try {
-                const decodedData = atob(encodedData);
-                const data = JSON.parse(decodedData);
-                
-                if (data.user && data.token) {
-                    login(data.user, data.token);
-                    navigate('/dashboard');
-                } else {
-                    throw new Error('Invalid data structure');
-                }
-            } catch (error) {
-                console.error('Failed to process authentication data:', error);
-                navigate('/login', { state: { error: 'Failed to process authentication data' } });
-            }
-        } else {
-            navigate('/login', { state: { error: 'No authentication data received' } });
-        }
-    }, [location, login, navigate]);
-
-    return (
-        <AuthContext.Provider value={{ user: user ?? null, login, logout, isLoading, handleAuthCallback }}>
-            {children}
-        </AuthContext.Provider>
+        return Promise.reject(error);
+      }
     );
+
+    // Cleanup interceptor on unmount
+    return () => {
+      axios.interceptors.response.eject(interceptor);
+    };
+  }, [logout, navigate, location, queryClient]);
+
+  const handleAuthCallback = useCallback(() => {
+    const params = new URLSearchParams(location.search);
+    const encodedData = params.get("data");
+    const error = params.get("error");
+
+    if (error) {
+      console.error("Authentication error:", error);
+      navigate("/login", { state: { error } });
+      return;
+    }
+
+    if (encodedData) {
+      try {
+        const decodedData = atob(encodedData);
+        const data = JSON.parse(decodedData);
+
+        if (data.user && data.token) {
+          login(data.user, data.token);
+          navigate("/dashboard");
+        } else {
+          throw new Error("Invalid data structure");
+        }
+      } catch (error) {
+        console.error("Failed to process authentication data:", error);
+        navigate("/login", {
+          state: { error: "Failed to process authentication data" },
+        });
+      }
+    } else {
+      navigate("/login", {
+        state: { error: "No authentication data received" },
+      });
+    }
+  }, [location, login, navigate]);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user: user ?? null,
+        login,
+        logout,
+        isLoading,
+        handleAuthCallback,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
 };

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -3,35 +3,36 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, ReactNode, useCallback } from "react";
 import { getToken, removeToken, storeToken } from "../utils/auth";
 import axios from "axios";
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from "react-router-dom";
 import { AuthContextType, UserProfile } from "../types/auth";
 
-
-export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(
+  undefined
+);
 
 const fetchUser = async () => {
-    const token = getToken();
-    if (!token) return null;
+  const token = getToken();
+  if (!token) return null;
 
-    const response = await axios.get(`api/api/user`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    });
+  const response = await axios.get(`api/api/user`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 
-    if (response.status !== 200) {
-        throw new Error('Failed to fetch user');
-    }
-    const userData = response.data.user
-    const user: UserProfile = {
-        id: userData.id,
-        display_name: userData.display_name,
-        email: userData.email,
-        uri: userData.uri,
-        country: userData.country,
-        image: userData.profile_image,
-    };
-    return user;
+  if (response.status !== 200) {
+    throw new Error("Failed to fetch user");
+  }
+  const userData = response.data.user;
+  const user: UserProfile = {
+    id: userData.id,
+    display_name: userData.display_name,
+    email: userData.email,
+    uri: userData.uri,
+    country: userData.country,
+    image: userData.profile_image,
+  };
+  return user;
 };
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,39 +1,15 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, ReactNode, useCallback } from "react";
-import { getToken, removeToken, storeToken } from "../utils/auth";
+import { removeToken, storeToken } from "../utils/auth";
 import axios from "axios";
 import { useNavigate, useLocation } from "react-router-dom";
 import { AuthContextType, UserProfile } from "../types/auth";
+import fetchUser from "../services/userService";
 
 export const AuthContext = createContext<AuthContextType | undefined>(
   undefined
 );
-
-const fetchUser = async () => {
-  const token = getToken();
-  if (!token) return null;
-
-  const response = await axios.get(`api/api/user`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (response.status !== 200) {
-    throw new Error("Failed to fetch user");
-  }
-  const userData = response.data.user;
-  const user: UserProfile = {
-    id: userData.id,
-    display_name: userData.display_name,
-    email: userData.email,
-    uri: userData.uri,
-    country: userData.country,
-    image: userData.profile_image,
-  };
-  return user;
-};
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const queryClient = useQueryClient();
@@ -71,7 +47,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           queryClient.clear();
           // Handle the logout
           logout();
-          // You might want to preserve the intended destination
+          // preserve the intended destination
           const destination = location.pathname;
           if (destination !== "/login") {
             navigate("/login", {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,21 +1,35 @@
 import { SpotifyOutlined } from "@ant-design/icons";
-import { Button, Col, Layout, Row } from "antd";
+import { Alert, Button, Col, Layout, Row } from "antd";
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import { Content } from "antd/es/layout/layout";
 import { config } from "../config";
 
+interface LocationState {
+  error?: string;
+  returnTo?: string;
+}
+
 const LoginPage = () => {
   const location = useLocation();
-  const error = location.state?.error;
+  const { error, returnTo } = (location.state as LocationState) || {};
   const { user } = useAuth();
 
   const handleSpotifyLogin = () => {
+    // Store the return path in localStorage before redirecting
+    if (returnTo) {
+      localStorage.setItem("returnTo", returnTo);
+    }
     window.location.href = `api/auth/spotify/login`;
   };
 
   if (user) {
-    return <Navigate to="/" replace />;
+    // Check if there's a stored return path
+    const storedReturnTo = localStorage.getItem("returnTo");
+    // Clean up the stored path
+    localStorage.removeItem("returnTo");
+    // Redirect to the stored path or home
+    return <Navigate to={storedReturnTo || "/"} replace />
   }
 
   return (
@@ -29,8 +43,16 @@ const LoginPage = () => {
         }}
       >
         <Row>
-          <Col>
-            {error && <p style={{ color: "red" }}>{error}</p>}
+          <Col style={{ width: "100%", maxWidth: 400 }}>
+            {error && (
+              <Alert
+                message="Authentication Error"
+                description={error}
+                type="error"
+                showIcon
+                style={{ marginBottom: 16 }}
+              />
+            )}
             <Button
               icon={<SpotifyOutlined />}
               type="primary"

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -29,7 +29,7 @@ const LoginPage = () => {
     // Clean up the stored path
     localStorage.removeItem("returnTo");
     // Redirect to the stored path or home
-    return <Navigate to={storedReturnTo || "/"} replace />
+    return <Navigate to={storedReturnTo || "/"} replace />;
   }
 
   return (

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { UserProfile } from "../types/auth";
+import { getToken } from "../utils/auth";
+
+const fetchUser = async () => {
+  const token = getToken();
+  if (!token) return null;
+
+  const response = await axios.get(`api/api/user`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (response.status !== 200) {
+    throw new Error("Failed to fetch user");
+  }
+  const userData = response.data.user;
+  const user: UserProfile = {
+    id: userData.id,
+    display_name: userData.display_name,
+    email: userData.email,
+    uri: userData.uri,
+    country: userData.country,
+    image: userData.profile_image,
+  };
+  return user;
+};
+
+export default fetchUser;


### PR DESCRIPTION
# Pull Request: Handle Session Expiration and Auth Flow Improvements

## Changes
- Added global axios interceptor in AuthContext to handle 401 errors
- Implemented return path preservation for expired sessions
- Enhanced login error display using Ant Design Alert
- Added localStorage management for return paths

## Motivation
When sessions expire after deployments/rebuilds, users get stuck with 401 errors. This update provides a smoother user experience by automatically redirecting to login and returning users to their intended destination after re-authentication.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update

## Testing
- Tested session expiration by manually clearing token
- Verified redirect to login with error message
- Confirmed return path functionality works after re-authentication
- Tested with Spotify OAuth flow

## Checklist
- [x] Code is self-reviewed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests added/updated (if applicable)

## Related Issues
#15 